### PR TITLE
Update release_to_azure_devops.yaml workflow

### DIFF
--- a/.github/workflows/release_to_azure_devops.yaml
+++ b/.github/workflows/release_to_azure_devops.yaml
@@ -1,58 +1,97 @@
 name: Release to Azure DevOps Marketplace
 
 on:
-  push:
-    tags:
-      - 'v*'
-  
+    push:
+        tags:
+            - 'v*'
+    pull_request:
+        branches:
+            - '**'
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -e {0}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+    package-and-publish:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                shell: bash -e {0}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
 
-      - name: Set version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV  
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 'lts/*'
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v2
-        with:
-          node-version: 'lts/*'
-        
-      - name: Install packages globally
-        run: npm install -g tfx-cli typescript
+            - name: Install packages globally
+              run: npm install -g tfx-cli typescript
 
-      - name: Restore npm packages
-        run: |
-         cd src/format-check
-         npm ci
+            - name: Set version (tag push)
+              if: startsWith(github.ref, 'refs/tags/v')
+              run: |
+                  VERSION=${GITHUB_REF#refs/tags/v}
+                  echo "EXT_VERSION=${VERSION}" >> $GITHUB_ENV
 
-      - name: Update task version
-        run: |
-          cd src/format-check
-          node ../../.github/workflows/update-task-version.js ${{ env.VERSION }} task.json
+            - name: Set version (PR)
+              if: github.event_name == 'pull_request'
+              run: |
+                  LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+                  echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_ENV
 
-      - name: Compile TypeScript
-        run: |
-         cd src/format-check
-         tsc
+                  IFS='.' read -ra VERSION_PARTS <<< "$LATEST_TAG"
+                  MAJOR=${VERSION_PARTS[0]}
+                  MINOR=${VERSION_PARTS[1]}
+                  PATCH=${VERSION_PARTS[2]}
 
-      - name: Publish to Azure DevOps Marketplace
-        id: publish
-        run: |
-          cd src
-          tfx extension publish --manifest-globs vss-extension.json --token "${{ secrets.AZURE_DEVOPS_PAT }}" --override "{\"version\": \"${{ env.VERSION }}\"}"
+                  NEXT_MINOR=$((MINOR + 1))
 
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ env.VERSION }}
-          draft: ${{ startsWith(github.ref, 'refs/tags/v') == false }}
-          prerelease: ${{ startsWith(github.ref, 'refs/tags/v') == false }}
+                  NEXT_VERSION="${MAJOR}.${NEXT_MINOR}.${PATCH}"
+                  echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
+
+                  EXT_VERSION="${NEXT_VERSION}-dev.${{ github.run_id }}"
+                  echo "EXT_VERSION=${EXT_VERSION}" >> $GITHUB_ENV
+
+            - name: Restore npm packages
+              run: npm ci
+              working-directory: src/format-check
+
+            - name: Update task version
+              run: node ../../.github/workflows/update-task-version.js ${{ env.EXT_VERSION }} task.json
+              working-directory: src/format-check
+
+            - name: Compile TypeScript
+              run: tsc
+              working-directory: src/format-check
+
+            - name: Package Extension
+              run: tfx extension create --manifests vss-extension.json --extension-version ${{ env.EXT_VERSION }}
+              working-directory: src
+
+            - name: Publish to Azure DevOps Marketplace
+              id: publish
+              env:
+                  PUBLISHER_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
+              run: echo $PUBLISHER_TOKEN | tfx extension publish --vsix ajeckmans.format-check.${{ env.EXT_VERSION }}.vsix --token
+              working-directory: src
+
+            - name: Create GitHub Release
+              id: create_release
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag_name: ${{ github.ref }}
+                  release_name: ${{ github.event_name == 'pull_request' && 'Prerelease' || 'Release' }} ${{ env.EXT_VERSION }}
+                  draft: ${{ github.event_name == 'pull_request' }}
+                  prerelease: ${{ github.event_name == 'pull_request' }}
+
+            - name: Upload .VSIX to GitHub Release
+              uses: actions/upload-release-asset@v1
+              if: startsWith(github.ref, 'refs/tags/v')
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: ./src/ajeckmans.format-check.${{ env.EXT_VERSION }}.vsix
+                  asset_name: ajeckmans.format-check.${{ env.EXT_VERSION }}.vsix
+                  asset_content_type: application/octet-stream

--- a/.github/workflows/release_to_azure_devops.yaml
+++ b/.github/workflows/release_to_azure_devops.yaml
@@ -66,7 +66,8 @@ jobs:
               working-directory: src/format-check
 
             - name: Package Extension
-              run: tfx extension create --manifests vss-extension.json --extension-version ${{ env.EXT_VERSION }}
+              run: |
+                tfx extension create --manifests vss-extension.json --override "{\"version\": \"${{ env.EXT_VERSION }}\"}"
               working-directory: src
 
             - name: Publish to Azure DevOps Marketplace

--- a/.github/workflows/release_to_azure_devops.yaml
+++ b/.github/workflows/release_to_azure_devops.yaml
@@ -50,7 +50,8 @@ jobs:
                   NEXT_VERSION="${MAJOR}.${NEXT_MINOR}.${PATCH}"
                   echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
 
-                  EXT_VERSION="${MAJOR}.${NEXT_MINOR}.${PATCH}.${GITHUB_RUN_ID}"
+                  SHORT_RUN_ID=$((${{ github.run_id }} % 1000000000))
+                  EXT_VERSION="${MAJOR}.${MINOR}.${PATCH}.${SHORT_RUN_ID}"
                   echo "EXT_VERSION=${EXT_VERSION}" >> $GITHUB_ENV
 
             - name: Restore npm packages

--- a/.github/workflows/release_to_azure_devops.yaml
+++ b/.github/workflows/release_to_azure_devops.yaml
@@ -72,9 +72,7 @@ jobs:
 
             - name: Publish to Azure DevOps Marketplace
               id: publish
-              env:
-                  PUBLISHER_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
-              run: echo $PUBLISHER_TOKEN | tfx extension publish --vsix ajeckmans.format-check-${{ env.EXT_VERSION }}.vsix --token
+              run: tfx extension publish --vsix ajeckmans.format-check-${{ env.EXT_VERSION }}.vsix --token ${{secrets.AZURE_DEVOPS_PAT}}
               working-directory: src
 
             - name: Create GitHub Release

--- a/.github/workflows/release_to_azure_devops.yaml
+++ b/.github/workflows/release_to_azure_devops.yaml
@@ -41,7 +41,7 @@ jobs:
                   echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_ENV
 
                   IFS='.' read -ra VERSION_PARTS <<< "$LATEST_TAG"
-                  MAJOR=${VERSION_PARTS[0]}
+                  MAJOR=${VERSION_PARTS[0]#v}
                   MINOR=${VERSION_PARTS[1]}
                   PATCH=${VERSION_PARTS[2]}
 

--- a/.github/workflows/release_to_azure_devops.yaml
+++ b/.github/workflows/release_to_azure_devops.yaml
@@ -68,7 +68,7 @@ jobs:
             - name: Package Extension
               run: |
                   tfx extension create --manifests vss-extension.json --override "{\"version\": \"${{ env.EXT_VERSION }}\"}"
-              working-directory: src+
+              working-directory: src
 
             - name: Publish to Azure DevOps Marketplace
               id: publish

--- a/.github/workflows/release_to_azure_devops.yaml
+++ b/.github/workflows/release_to_azure_devops.yaml
@@ -67,14 +67,14 @@ jobs:
 
             - name: Package Extension
               run: |
-                tfx extension create --manifests vss-extension.json --override "{\"version\": \"${{ env.EXT_VERSION }}\"}"
-              working-directory: src
+                  tfx extension create --manifests vss-extension.json --override "{\"version\": \"${{ env.EXT_VERSION }}\"}"
+              working-directory: src+
 
             - name: Publish to Azure DevOps Marketplace
               id: publish
               env:
                   PUBLISHER_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
-              run: echo $PUBLISHER_TOKEN | tfx extension publish --vsix ajeckmans.format-check.${{ env.EXT_VERSION }}.vsix --token
+              run: echo $PUBLISHER_TOKEN | tfx extension publish --vsix ajeckmans.format-check-${{ env.EXT_VERSION }}.vsix --token
               working-directory: src
 
             - name: Create GitHub Release
@@ -95,6 +95,6 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   upload_url: ${{ steps.create_release.outputs.upload_url }}
-                  asset_path: ./src/ajeckmans.format-check.${{ env.EXT_VERSION }}.vsix
+                  asset_path: ./src/ajeckmans.format-check-${{ env.EXT_VERSION }}.vsix
                   asset_name: ajeckmans.format-check.${{ env.EXT_VERSION }}.vsix
                   asset_content_type: application/octet-stream

--- a/.github/workflows/release_to_azure_devops.yaml
+++ b/.github/workflows/release_to_azure_devops.yaml
@@ -50,7 +50,7 @@ jobs:
                   NEXT_VERSION="${MAJOR}.${NEXT_MINOR}.${PATCH}"
                   echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
 
-                  EXT_VERSION="${NEXT_VERSION}-dev.${{ github.run_id }}"
+                  EXT_VERSION="${MAJOR}.${NEXT_MINOR}.${PATCH}.${GITHUB_RUN_ID}"
                   echo "EXT_VERSION=${EXT_VERSION}" >> $GITHUB_ENV
 
             - name: Restore npm packages

--- a/.github/workflows/release_to_azure_devops.yaml
+++ b/.github/workflows/release_to_azure_devops.yaml
@@ -50,7 +50,7 @@ jobs:
                   NEXT_VERSION="${MAJOR}.${NEXT_MINOR}.${PATCH}"
                   echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
 
-                  SHORT_RUN_ID=$((${{ github.run_id }} % 1000000000))
+                  SHORT_RUN_ID=$((${{ github.run_id }} % 2147483647))
                   EXT_VERSION="${MAJOR}.${MINOR}.${PATCH}.${SHORT_RUN_ID}"
                   echo "EXT_VERSION=${EXT_VERSION}" >> $GITHUB_ENV
 

--- a/.github/workflows/release_to_azure_devops.yaml
+++ b/.github/workflows/release_to_azure_devops.yaml
@@ -35,6 +35,8 @@ jobs:
             - name: Set version (PR)
               if: github.event_name == 'pull_request'
               run: |
+                  git fetch --tags
+
                   LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
                   echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_ENV
 


### PR DESCRIPTION
This commit modifies the `.github/workflows/release_to_azure_devops.yaml` file. The changes include:
- Adding the `pull_request` event trigger for workflow execution on all branches of all pull requests.
- Renaming the `build` job to `package-and-publish` for better clarity.
- Setting the version dynamically based on the Git tag for tag pushes. The version is extracted from the `GITHUB_REF` environment variable and stored as `EXT_VERSION` in the `GITHUB_ENV` environment file.
- For pull requests, the version is determined by finding the latest tag, splitting it into major, minor, and patch components, incrementing the minor version, and appending ".0-dev" and the GitHub run ID to create `EXT_VERSION`.
- Restoring npm packages using `npm ci` in the `src/format-check` directory.
- Updating the task version by running the `update-task-version.js` script with the `EXT_VERSION` variable and `task.json` as arguments in the `src/format-check` directory.
- Compiling TypeScript files in the `src/format-check` directory using `tsc` command.
- Packaging the extension using `tfx extension create` command with the `vss-extension.json` manifest and the `EXT_VERSION` as the extension version in the `src` directory.
- Publishing the extension to Azure DevOps Marketplace using `tfx extension publish` command with the `vss-extension.json` manifest and the `VERSION` as the extension version in the `src` directory.
- Creating a GitHub release with the tag name, release name, draft status, and prerelease status. The release name is determined based on the event name. If it's a pull request event, the release name is set as "Prerelease EXT_VERSION". Otherwise, it's set as "Release EXT_VERSION".
- Uploading the `.VSIX` file to the GitHub release as an asset.