### PR TITLE
Refactor format-check script to include path options

### DIFF
--- a/src/format-check/task.json
+++ b/src/format-check/task.json
@@ -9,7 +9,9 @@
         "Node10": {
             "target": "scripts/format-check.js",
             "inputs": {
-                "solutionPath": "INPUT_SOLUTIONPATH"
+                "solutionPath": "INPUT_SOLUTIONPATH",
+                "includePath": "INPUT_INCLUDEPATH",
+                "excludePath": "INPUT_EXCLUDEPATH"
             }
         }
     },
@@ -21,6 +23,22 @@
             "defaultValue": "",
             "required": true,
             "helpMarkDown": "Specify the path to the solution directory."
+        },
+        {
+            "name": "IncludePath",
+            "type": "string",
+            "label": "Include Path",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Specify the path to be included."
+        },
+        {
+            "name": "ExcludePath",
+            "type": "string",
+            "label": "Exclude Path",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Specify the path to be excluded."
         }
     ]
 }


### PR DESCRIPTION
- The task now supports the use of includePath and excludePath for better control over the format checking scope.
- On failure of the dotnet format command, the task exits with non-zero code and displays error messages.
- The task only fails if there are active issues, otherwise it marks as success.