### PR TITLE
Skip thread creation for deleted files in the PR.

### DIFF
--- a/src/format-check/scripts/format-check.ts
+++ b/src/format-check/scripts/format-check.ts
@@ -234,6 +234,11 @@ async function updatePullRequestThreads(
                 };
                 await pullRequestService.updateThread(thread, existingThread.id);
             } else {
+                if (report.changeType === gi.VersionControlChangeType.Delete) {
+                    console.log(`Skipping creating thread for deleted file ${report.FilePath}.`);
+                    continue;
+                }
+                
                 console.log(`📝 Creating new thread for file ${report.FilePath}.`);
                 const thread = <gi.GitPullRequestCommentThread>{
                     comments: [comment],


### PR DESCRIPTION
When the branch is not up-to-date the merging commit will be checked as well. Some files will be deleted on the local pull, when they are available on the parent branch, but not on the checked branch. If the deleted file has issues, those will appear in the PR even if they are not part of the PR.